### PR TITLE
docs(translation): English translation of BMS comments

### DIFF
--- a/ADV2/BMS/Source/App/BMS_Protection.c
+++ b/ADV2/BMS/Source/App/BMS_Protection.c
@@ -11,33 +11,33 @@
 
 /**************************************************
  * @brie  :BMS_Overvoltage_Protection()
- * @note  :过压保护
- * @param :无
- * @retval:无
+ * @note  :Overvoltage protection [过压保护]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void BMS_Overvoltage_Protection(void)
 {
 	uint8_t clean_flag = 0xFF,r0;
 	uint8_t i = 0;
 	
-	if(g_AfeRegs.R0.bitmap.COV)		//发生电池过压
+	if(g_AfeRegs.R0.bitmap.COV)		//Overvoltage protection [发生电池过压]
 	{
-		CHARG_OFF;					//关闭充电器
-		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[3] = 9900;	//错误代码
+		CHARG_OFF;					//Turn off the charger [关闭充电器]
+		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[3] = 9900;	//Overvoltage protection [错误代码]
 		Flag.Overvoltage = 1;
 		
-		if(newBals == 0)	//过压保护解除
+		if(newBals == 0)	//Overvoltage protection lifting [过压保护解除]
 		{
 			Flag.Overvoltage = 0;
-			if((CHARGER == 1) && (Flag.Charging_Overcurrent == 0)) //过压保护解除并且没有发生充电过流
+			if((CHARGER == 1) && (Flag.Charging_Overcurrent == 0)) //Overvoltage protection lifting [过压保护解除并且没有发生充电过流]
 			{
-				if((Flag.Overtemperature == 0) && (Flag.Lowtemperature == 0))	//没有发生过温和低温
+				if((Flag.Overtemperature == 0) && (Flag.Lowtemperature == 0))	//Overvoltage protection is lifted and there is no charging overcurrent [没有发生过温和低温]
 				{
 					Flag.Charger_ON = 0;
 				}
 				
 			}
-			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[3] = 0;	//错误代码
+			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[3] = 0;	//Error code [错误代码]
 			
 			r0 = g_AfeRegs.R0.cleanflag;
 			clean_flag &= ~(1<<6);
@@ -54,20 +54,20 @@ void BMS_Overvoltage_Protection(void)
 
 /**************************************************
  * @brie  :BMS_Undervoltage_Protection()
- * @note  :欠压保护
- * @param :无
- * @retval:无
+ * @note  :Arrears protection [欠压保护]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void BMS_Undervoltage_Protection(void)
 {
 	uint8_t clean_flag = 0xFF,r0;
 	uint8_t i = 0,val = 0;
 	
-	if(g_AfeRegs.R0.bitmap.CUV)		//发生电池欠压
+	if(g_AfeRegs.R0.bitmap.CUV)		//Battery pressure occurs [发生电池欠压]
 	{
 		Flag.Undervoltage = 1;
-		Flag.Cock_Head = 1;//翘头
-		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[4] = 9900;	//错误代码
+		Flag.Cock_Head = 1; 		//Head tilted [翘头]
+		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[4] = 9900;	//Error code [错误代码]
 		
 		for(i=0;i<AFE_MAX_CELL_CNT;i++)
 		{
@@ -77,36 +77,36 @@ void BMS_Undervoltage_Protection(void)
 			}
 		}
 		
-		if(val == 0)	//所有电池电压均大于3.5V
+		if(val == 0)	//All battery voltage is greater than 3.5V [所有电池电压均大于3.5V]
 		{
 			i = 0;
 			
-			if(Flag.Electric_Discharge_Overcurrent == 0)	//没有发生放电过流
+			if(Flag.Electric_Discharge_Overcurrent == 0)	//No discharge overcurrent [没有发生放电过流]
 			{
 				if(Flag.Lowtemperature == 1)
 				{
-					if(CHARGER == 1)	//低温保护但是正在充电
+					if(CHARGER == 1)	//Low temperature protection but charging [低温保护但是正在充电]
 					{
-						Flag.Cock_Head = 0;//不翘头
+						Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 					}
 				}
 				else
 				{
 					if(Flag.Overtemperature == 1)	
 					{
-						if(CHARGER == 1)	//高温保护但是正在充电
+						if(CHARGER == 1)	//High temperature protection but charging [高温保护但是正在充电]
 						{
-							Flag.Cock_Head = 0;//不翘头
+							Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 						}
 					}
 					else
 					{
-						Flag.Cock_Head = 0;//不翘头
+						Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 					}
 				}				
 			}
 			
-			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[4] = 0;	//错误代码
+			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[4] = 0;	//Error code [错误代码]
 			
 			r0 = g_AfeRegs.R0.cleanflag;
 			clean_flag &= ~(1<<5);
@@ -123,9 +123,9 @@ void BMS_Undervoltage_Protection(void)
 
 /**************************************************
  * @brie  :BMS_Discharge_Overcurrent_Protection()
- * @note  :放电过流保护
- * @param :无
- * @retval:无
+ * @note  :Discharge overcurrent protection [放电过流保护]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void BMS_Discharge_Overcurrent_Protection(void)
 {
@@ -133,57 +133,57 @@ void BMS_Discharge_Overcurrent_Protection(void)
 	uint8_t i = 0;
 	static uint8_t lock = 0;
 	
-	//if(g_AfeRegs.R0.bitmap.OCD2)	//发生2级放电过流
+	//if(g_AfeRegs.R0.bitmap.OCD2)	//Level 2 discharge overcurrent occurs [发生2级放电过流]
 	
-	if(DVC_1124.Current_CC2 > 115)	//115A过流
+	if(DVC_1124.Current_CC2 > 115)	//115A overcurrent [115A过流]
 	{
 		Flag.Electric_Discharge_Overcurrent = 1;
-		Flag.Cock_Head = 1;//翘头
-		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[5] = 9900;	//错误代码
+		Flag.Cock_Head = 1;		//Head tilted [翘头]
+		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[5] = 9900;	//Error code [错误代码]
 		
-		if(lock == 0)	//触发保护第一次进来
+		if(lock == 0)	//Trigger protection comes in for the first time [触发保护第一次进来]
 		{
-			if((VESC_CAN_RX_DATA.pSTATUS->Rpm > 100) || (VESC_CAN_RX_DATA.pSTATUS->Rpm < -100))	//速度大于±100
+			if((VESC_CAN_RX_DATA.pSTATUS->Rpm > 100) || (VESC_CAN_RX_DATA.pSTATUS->Rpm < -100))		//Speed ??greater than ±100 [速度大于±100]
 			{
 				Software_Counter_1ms.Discharge_Overcurrent_Delay = 0;
 			}
-			else //速度在±100以内
+			else 	//Speed ??within ±100 [速度在±100以内]
 			{
 				Software_Counter_1ms.Discharge_Overcurrent_Delay = 0;
 				lock = 1;
 			}
 		}
 	
-		if((Software_Counter_1ms.Discharge_Overcurrent_Delay >= 2000) && (lock == 1)) //速度在±100并保持了2S
+		if((Software_Counter_1ms.Discharge_Overcurrent_Delay >= 2000) && (lock == 1)) 	//The speed is ±100 and maintained for 2S [速度在±100并保持了2S]
 		{
 			lock = 0;
 			
-			if(Flag.Undervoltage == 0)	//没有发生欠压
+			if(Flag.Undervoltage == 0)	//No undervoltage occurred [没有发生欠压]
 			{
 				if(Flag.Lowtemperature == 1)
 				{
-					if(CHARGER == 1)	//低温保护但是正在充电
+					if(CHARGER == 1)	//Low temperature protection but charging [低温保护但是正在充电]
 					{
-						Flag.Cock_Head = 0;//不翘头
+						Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 					}
 				}
 				else
 				{
 					if(Flag.Overtemperature == 1)	
 					{
-						if(CHARGER == 1)	//高温保护但是正在充电
+						if(CHARGER == 1)	//High temperature protection but charging [高温保护但是正在充电]
 						{
-							Flag.Cock_Head = 0;//不翘头
+							Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 						}
 					}
 					else
 					{
-						Flag.Cock_Head = 0;//不翘头
+						Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 					}
 				}		
 			}
 			
-			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[5] = 0;	//错误代码
+			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[5] = 0;	//Error code [错误代码]
 			
 			r0 = g_AfeRegs.R0.cleanflag;
 			clean_flag &= ~(1<<2);
@@ -201,28 +201,28 @@ void BMS_Discharge_Overcurrent_Protection(void)
 		Flag.Electric_Discharge_Overcurrent = 0;
 		lock = 0;
 		Software_Counter_1ms.Discharge_Overcurrent_Delay = 0;
-		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[5] = 0;	//错误代码
-		if(Flag.Undervoltage == 0)	//没有发生欠压
+		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[5] = 0;	//Error code [错误代码]
+		if(Flag.Undervoltage == 0)	//No undervoltage occurred [没有发生欠压]
 		{
 			if(Flag.Lowtemperature == 1)
 			{
-				if(CHARGER == 1)	//低温保护但是正在充电
+				if(CHARGER == 1)	//Low temperature protection but charging [低温保护但是正在充电]
 				{
-					Flag.Cock_Head = 0;//不翘头
+					Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 				}
 			}
 			else
 			{
 				if(Flag.Overtemperature == 1)	
 				{
-					if(CHARGER == 1)	//高温保护但是正在充电
+					if(CHARGER == 1)	//High temperature protection but charging [高温保护但是正在充电]
 					{
-						Flag.Cock_Head = 0;//不翘头
+						Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 					}
 				}
 				else
 				{
-					Flag.Cock_Head = 0;//不翘头
+					Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 				}
 			}		
 		}
@@ -231,9 +231,9 @@ void BMS_Discharge_Overcurrent_Protection(void)
 
 /**************************************************
  * @brie  :BMS_Charge_Overcurrent_Protection()
- * @note  :充电过流保护
- * @param :无
- * @retval:无
+ * @note  :Charging overcurrent protection [充电过流保护]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void BMS_Charge_Overcurrent_Protection(void)
 {
@@ -241,28 +241,28 @@ void BMS_Charge_Overcurrent_Protection(void)
 	uint8_t i = 0;
 	static uint8_t lock = 0;
 	
-	//if(g_AfeRegs.R0.bitmap.OCC2)	//发生2级充电过流
+	//if(g_AfeRegs.R0.bitmap.OCC2)	//Level 2 charging overcurrent occurs [发生2级充电过流]
 	
-	if(DVC_1124.Current_CC2 < -20)	//20A过流
+	if(DVC_1124.Current_CC2 < -20)	//20A overcurrent [20A过流]
 	{
 		Flag.Charging_Overcurrent = 1;
-		CHARG_OFF;					//关闭充电器
-		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[6] = 9900;	//错误代码
+		CHARG_OFF;					//Turn off charger [关闭充电器]
+		VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[6] = 9900;	//Error code [错误代码]
 		lock = 1;
 		Software_Counter_1ms.Charge_Overcurrent_Delay = 0;
 	}
-	else if(DVC_1124.Current_CC2 > -1) //1A
+	else if(DVC_1124.Current_CC2 > -1) //1 Amp [1A]
 	{
 		if(lock == 1)
 		{
 			if(Software_Counter_1ms.Charge_Overcurrent_Delay > 10000)
 			{
 				lock = 0;
-				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[6] = 0;	//错误代码
+				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[6] = 0;	//Error code [错误代码]
 				
-				if((CHARGER == 1) && (Flag.Overvoltage == 0))	//充电器插入并且没有发生过压
+				if((CHARGER == 1) && (Flag.Overvoltage == 0))	//The charger is plugged in and no overvoltage occurs [充电器插入并且没有发生过压]
 				{
-					if((Flag.Overtemperature == 0) && (Flag.Lowtemperature == 0))	//没有发生过温和低温
+					if((Flag.Overtemperature == 0) && (Flag.Lowtemperature == 0))	//Mild and low temperatures have not occurred [没有发生过温和低温]
 					{
 						Flag.Charger_ON = 0;
 					}
@@ -284,13 +284,13 @@ void BMS_Charge_Overcurrent_Protection(void)
 
 /**************************************************
  * @brie  :BMS_Short_Circuit_Protection()
- * @note  :短路保护
- * @param :无
- * @retval:无
+ * @note  :Short circuit protection [短路保护]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void BMS_Short_Circuit_Protection(void)
 {
-	if(g_AfeRegs.R0.bitmap.SCD)		//发生放电短路
+	if(g_AfeRegs.R0.bitmap.SCD)		//Discharge short circuit occurs [发生放电短路]
 	{
 		DSG_OFF;
 		CHG_OFF;
@@ -304,15 +304,15 @@ void BMS_Short_Circuit_Protection(void)
 
 /**************************************************
  * @brie  :BMS_Overtemperature_Protection()
- * @note  :过温保护
- * @param :无
- * @retval:无
+ * @note  :Over temperature protection [过温保护]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void BMS_Overtemperature_Protection(void)
 {
 	static uint8_t lock = 0;
 	
-	if(lock == 0)	//没发生过温
+	if(lock == 0)	//No overheating occurred [没发生过温]
 	{
 		if( (DVC_1124.IC_Temp > 80.0f) ||
 			(DVC_1124.GP3_Temp > 85.0f) ||
@@ -321,13 +321,13 @@ void BMS_Overtemperature_Protection(void)
 			) 
 		{
 			Flag.Overtemperature = 1;
-			CHARG_OFF;					//关闭充电器
-			Flag.Cock_Head = 1;			//翘头
-			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[7] = 9900;	//错误代码
+			CHARG_OFF;					//Turn off charger [关闭充电器]
+			Flag.Cock_Head = 1;			//Head tilted [翘头]
+			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[7] = 9900;	//Error code [错误代码]
 			lock = 1;
 		}
 	}
-	else	//已经发生过温
+	else	//Overheating has occurred [已经发生过温]
 	{
 		if( (DVC_1124.IC_Temp < 75.0f) &&
 			(DVC_1124.GP3_Temp < 80.0f) &&
@@ -337,26 +337,26 @@ void BMS_Overtemperature_Protection(void)
 		{
 			Flag.Overtemperature = 0;
 			lock = 0;
-			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[7] = 0;	//错误代码 T9
+			VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[7] = 0;	//Error code [错误代码 T9]
 			
-			if((Flag.Undervoltage == 0) && (Flag.Electric_Discharge_Overcurrent == 0))	//没有发生欠压 没有发生放电过流
+			if((Flag.Undervoltage == 0) && (Flag.Electric_Discharge_Overcurrent == 0))	//No undervoltage occurs. No discharge overcurrent occurs. [没有发生欠压 没有发生放电过流]
 			{
 				if(Flag.Lowtemperature == 1)
 				{
-					if(CHARGER == 1)	//低温保护但是正在充电
+					if(CHARGER == 1)	//Low temperature protection but charging [低温保护但是正在充电]
 					{
-						Flag.Cock_Head = 0;//不翘头
+						Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 					}
 				}
 				else
 				{
-					Flag.Cock_Head = 0;//不翘头
+					Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 				}		
 			}
 			
-			if((CHARGER == 1) && (Flag.Overvoltage == 0) && (Flag.Charging_Overcurrent == 0))	//充电器插入并且没有发生过压 没有发生充电过流
+			if((CHARGER == 1) && (Flag.Overvoltage == 0) && (Flag.Charging_Overcurrent == 0))	//The charger is plugged in and no overvoltage occurs. No charging overcurrent occurs. [充电器插入并且没有发生过压 没有发生充电过流]
 			{
-				if((Flag.Lowtemperature == 0))	//没有发生低温
+				if((Flag.Lowtemperature == 0))	//No hypothermia occurred [没有发生低温]
 				{
 					Flag.Charger_ON = 0;
 				}
@@ -367,15 +367,15 @@ void BMS_Overtemperature_Protection(void)
 
 /**************************************************
  * @brie  :BMS_Low_Temperature_Protection()
- * @note  :低温保护
- * @param :无
- * @retval:无
+ * @note  :Low temperature protection [低温保护]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void BMS_Low_Temperature_Protection(void)
 {
 	static uint8_t lock = 0;
 	
-	if(lock == 0)	//没发生低温
+	if(lock == 0)	//No hypothermia occurred [没发生低温]
 	{
 		if(CHARGER == 1)
 		{
@@ -384,8 +384,8 @@ void BMS_Low_Temperature_Protection(void)
 				)
 			{
 				Flag.Lowtemperature = 1;
-				CHARG_OFF;					//关闭充电器
-				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[8] = 9900;	//错误代码
+				CHARG_OFF;					//Turn off charger [关闭充电器]
+				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[8] = 9900;	//Error code [错误代码]
 				lock = 1;
 			}
 		}
@@ -396,13 +396,13 @@ void BMS_Low_Temperature_Protection(void)
 				)
 			{
 				Flag.Lowtemperature = 1;
-				Flag.Cock_Head = 1;			//翘头
-				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[8] = 9900;	//错误代码
+				Flag.Cock_Head = 1;			//Head tilted [翘头]
+				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[8] = 9900;	//Error code [错误代码]
 				lock = 1;
 			}
 		}
 	}
-	else //已经发生低温
+	else //Low temperature has occurred [已经发生低温]
 	{
 		if(CHARGER == 1)
 		{
@@ -410,14 +410,14 @@ void BMS_Low_Temperature_Protection(void)
 				(DVC_1124.GP4_Temp > -5.0f)		
 				)
 			{
-				if((CHARGER == 1) && (Flag.Overvoltage == 0) && (Flag.Charging_Overcurrent == 0))	//充电器插入并且没有发生过压 没有发生充电过流
+				if((CHARGER == 1) && (Flag.Overvoltage == 0) && (Flag.Charging_Overcurrent == 0))	//The charger is plugged in and no overvoltage occurs. No charging overcurrent occurs. [充电器插入并且没有发生过压 没有发生充电过流]
 				{
-					if((Flag.Overtemperature == 0))	//没有发生低温
+					if((Flag.Overtemperature == 0))	//No hypothermia occurred [没有发生低温]
 					{
 						Flag.Charger_ON = 0;
 					}
 				}
-				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[8] = 0;	//错误代码
+				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[8] = 0;	//Error code [错误代码]
 				Flag.Lowtemperature = 0;
 				lock = 0;
 			}
@@ -428,21 +428,21 @@ void BMS_Low_Temperature_Protection(void)
 				(DVC_1124.GP4_Temp > -15.0f)		
 				)
 			{
-				if((Flag.Undervoltage == 0) && (Flag.Electric_Discharge_Overcurrent == 0))	//没有发生欠压 没有发生放电过流
+				if((Flag.Undervoltage == 0) && (Flag.Electric_Discharge_Overcurrent == 0))	//No undervoltage occurs. No discharge overcurrent occurs. [没有发生欠压 没有发生放电过流]
 				{
 					if(Flag.Overtemperature == 1)
 					{
-						if(CHARGER == 1)	//低温保护但是正在充电
+						if(CHARGER == 1)	//Low temperature protection but charging [低温保护但是正在充电]
 						{
-							Flag.Cock_Head = 0;//不翘头
+							Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 						}
 					}
 					else
 					{
-						Flag.Cock_Head = 0;//不翘头
+						Flag.Cock_Head = 0;		//Don't tilt your head [不翘头]
 					}		
 				}
-				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[8] = 0;	//错误代码
+				VESC_CAN_DATA.pBMS_TEMPS->BMS_Single_Temp[8] = 0;	//Error code [错误代码]
 				Flag.Lowtemperature = 0;
 				lock = 0;
 			}
@@ -454,16 +454,16 @@ void BMS_Low_Temperature_Protection(void)
 //#define B1 1500
 /**************************************************
  * @brie  :VESC_Cock_Head()
- * @note  :VESC翘头
- * @param :无
- * @retval:无
+ * @note  :VESC Head tilted [VESC翘头]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void VESC_Cock_Head(void)
 {
 	static uint8_t lock = 0;
 	if(lock == 0)
 	{
-		if(Flag.Cock_Head == 1)	//需要翘头
+		if(Flag.Cock_Head == 1)	//Need to raise your head [需要翘头]
 		{
 			if(VESC_CAN_RX_DATA.pSTATUS->Rpm > 0)
 			{
@@ -489,19 +489,19 @@ void VESC_Cock_Head(void)
 	
 /**************************************************
  * @brie  :DVC1124_Abnormal()
- * @note  :DVC1124异常处理
- * @param :无
- * @retval:无
+ * @note  :DVC1124 Exception Handling [DVC1124异常处理]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void BMS_Protection_Task(void)
 {
-	BMS_Overvoltage_Protection();			//过压保护		T5
-	BMS_Undervoltage_Protection();			//欠压保护		T6
-	BMS_Discharge_Overcurrent_Protection();	//放电过流保护	T7
-	BMS_Charge_Overcurrent_Protection();	//充电过流保护	T8
-	BMS_Short_Circuit_Protection();			//短路保护		
-	BMS_Overtemperature_Protection();		//过温保护		T9
-	BMS_Low_Temperature_Protection();		//低温保护		T10
+	BMS_Overvoltage_Protection();			//T5  Overvoltage protection 			[过压保护		T5]	
+	BMS_Undervoltage_Protection();			//T6  Under voltage protection			[欠压保护		T6]
+	BMS_Discharge_Overcurrent_Protection();	//T7  Discharge overcurrent protection	[放电过流保护	T7]
+	BMS_Charge_Overcurrent_Protection();	//T8  Charging overcurrent protection	[充电过流保护	T8]
+	BMS_Short_Circuit_Protection();			//    Short circuit protection			[短路保护		  ]
+	BMS_Overtemperature_Protection();		//T9  Over temperature protection		[过温保护		T9]
+	BMS_Low_Temperature_Protection();		//T10 Low temperature protection		[低温保护		T10]
 	VESC_Cock_Head();
 }
 

--- a/ADV2/BMS/Source/App/Initial.c
+++ b/ADV2/BMS/Source/App/Initial.c
@@ -3,7 +3,7 @@
 ;  *   	@Create Date         2023.09.20
 ;  *    @Official website		 http://www.devechip.com/
 ;  *----------------------Abstract Description---------------------------------
-;  *			          					系统初始化                              		
+;  * 	System initialization	[系统初始化]
 ******************************************************************************/
 #include "DVC11XX.h"
 #include "iic1.h"
@@ -13,30 +13,30 @@
 //------------------------------------------------------------------------------
 
 /**
-	* @说明	AFE初始化配置写入
-	* @参数	寄存器自定义参数默认值
-	* @返回值	成功/失败
-	* @注	
+	* @Description AFE initialization configuration writing 	[说明	AFE初始化配置写入]
+	* @Parameter Register custom parameter default value 		[参数	寄存器自定义参数默认值]
+	* @Return value success/failure 							[返回值	成功/失败]
+	* @Note 													[注]
 */
 static bool DVC11XX_InitRegs(void){
 	memcpy((char *)&g_AfeRegs+81,DVC11XX_PresetConfigRegData_R81To121,sizeof(DVC11XX_PresetConfigRegData_R81To121));
 	return DVC11XX_WriteRegs(AFE_ADDR_R(81),sizeof(DVC11XX_PresetConfigRegData_R81To121));
 }
 /**
-	* @说明	清除所有警报
-	* @参数	
-	* @返回值	
-	* @注	
+	* @Description Clear all alerts 	[说明	清除所有警报]
+	* @Parameter						[参数]
+	* @Return value						[返回值]
+	* @Note								[注]
 */
 void CleanError(void){
 g_AfeRegs.R0.cleanflag=0;
 	while(!DVC11XX_WriteRegs(AFE_ADDR_R(0),1));
 }
 /**
-	* @说明	GPIO初始化
-	* @参数	
-	* @返回值	
-	* @注	
+	* @Description GPIO initialization	[说明	GPIO初始化]
+	* @Parameter 						[参数]
+	* @Return value						[返回值]
+	* @Note								[注]
 */
 //void DVC11XX_GPIO_Init(void){
 //	//IO REMAP(Disable JTAG-DP and enable SW-DP)
@@ -45,10 +45,10 @@ g_AfeRegs.R0.cleanflag=0;
 //	GPIO_PinRemapConfig(GPIO_Remap_SWJ_JTAGDisable, ENABLE); //PB3,PB4,PA15用作GPIO,而PA13及PA14用作默认的SWD
 //}
 /**
-	* @说明	AFE芯片重新初始化
-	* @参数	
-	* @返回值	成功/失败
-	* @注	
+	* @Description AFE chip reinitialization	[说明	AFE芯片重新初始化]
+	* @Parameter 								[参数]
+	* @Return value success/failure				[返回值	成功/失败]
+	* @Note										[注]
 */
 bool DVC11XX_InitRegs_Twice(void){
 
@@ -57,21 +57,21 @@ return DVC11XX_InitRegs();
 }
 
 /**
-	* @说明	系统初始化
-	* @参数	
-	* @返回值	
-	* @注	
+	* @Description System initialization	[说明	系统初始化]
+	* @Parameter 							[参数]
+	* @Return value							[返回值]
+	* @Note									[注]
 */
 void Initial(void){
 	
-//    delay_ms(256);	//4. 延时256ms（确保AFE芯片至少完成一个周期的电压和电流值的测量）
-	IIC_Wakeup();	//7.唤醒AFE芯片
-	IIC1_Init();    //8. 初始化IIC通信接口(MCU跟AFE的通信接口）
+//    delay_ms(256);	//4. Delay 256ms (make sure the AFE chip completes at least one cycle of voltage and current measurement) [4. 延时256ms（确保AFE芯片至少完成一个周期的电压和电流值的测量]
+	IIC_Wakeup();		//7. Wake up the AFE chip [7.唤醒AFE芯片]
+	IIC1_Init();    	//8. Initialize the IIC communication interface (communication interface between MCU and AFE) [8. 初始化IIC通信接口(MCU跟AFE的通信接口）]
 #if ADDRESS>=0xC0
 	GPIO_INTPUT();
 #elif ADDRESS==0x40
 	IIC_SLAVE_ADDRESS=ADDRESS>>1;
 #endif	
-	while(!DVC11XX_InitRegs());  //8. AFE芯片寄存器初始化（写入用户自定义的配置数据）
-	CleanError();//写入默认值后清除警报
+	while(!DVC11XX_InitRegs());		//8. AFE chip register initialization (writing user-defined configuration data)   [8. AFE芯片寄存器初始化（写入用户自定义的配置数据]
+	CleanError();	//Clear alert after writing default value [写入默认值后清除警报]
 }

--- a/ADV2/BMS/Source/App/flag.h
+++ b/ADV2/BMS/Source/App/flag.h
@@ -22,60 +22,72 @@ extern Software_Counter_Type Software_Counter_1ms;
 typedef struct
 {
 	/*
-		Power = 0;	//刚开机
-		Power = 1;	//开机
-		Power = 2;	//开机完成
-		Power = 3;	//关机
-		Power = 4;	//关机后继续平衡充
+		Power = 0;	//Just turned on [刚开机]
+		Power = 1;	//Power on [开机]
+		Power = 2;	//Boot completed [开机完成]
+		Power = 3;	//Shut down [关机]
+		Power = 4;	//Continue balance charging after shutting down [关机后继续平衡充]
 	*/
 	uint8_t Power:3;
 	/*
-		1按键开机 	0按键关机
+		1:button to turn on, 
+		0:button to turn off [1按键开机 0按键关机]
 	*/
 	uint8_t Key_Boot:1;
 	/*
-		1充电器开机	0充电器关机
+		1:The charger is on, 
+		0:The charger is off [1充电器开机	0充电器关机]
 	*/
 	uint8_t Charger_Boot:1;
 	/*
-		0充电器准备开机	1充电器打开完成
+		0:The charger is ready to be turned on, 
+		1:The charger is turned on [0充电器准备开机	1充电器打开完成]
 	*/
 	uint8_t Charger_ON:1;
 	/*
-		0没有发生短路	1发生短路
+		0:No short circuit occurs, 
+		1:Short circuit occurs [0没有发生短路 1发生短路]
 	*/
 	uint8_t Short_Circuit:1;
 	/*
-		0不翘头	1翘头
+		0:Not warped, 
+		1:Warped [0不翘头	1翘头]
 	*/
 	uint8_t Cock_Head:1;
 	
 	/*
-		0没有过压	1发生过压
+		0:No overvoltage, 
+		1:Overvoltage occurs [0没有过压 1发生过压]
 	*/
 	uint8_t Overvoltage:1;
 	/*
-		0没有欠压	1发生欠压
+		0:No undervoltage 
+		1:Undervoltage occurs [0没有欠压 1发生欠压]
 	*/
 	uint8_t Undervoltage:1;
 	/*
-		0没有充电过流	1发生充电过流
+		0:No charging overcurrent, 
+		1:Charging overcurrent occurs [0没有充电过流	1发生充电过流]
 	*/
 	uint8_t Charging_Overcurrent:1;
 	/*
-		0没有放电过流	1发生放电过流
+		0:No discharge overcurrent, 
+		1:Discharge overcurrent occurs [0没有放电过流 1发生放电过流]
 	*/
 	uint8_t Electric_Discharge_Overcurrent:1;
 	/*
-		0没有过温	1发生过温
+		0:No overheating, 
+		1:Overheating occurs [0没有过温 1发生过温]
 	*/
 	uint8_t Overtemperature:1;
 	/*
-		0没有低温温	1发生低温
+		0:No low temperature,
+		1:Low temperature occurs [0没有低温温 1发生低温]
 	*/
 	uint8_t Lowtemperature:1;
 	/*
-		0没有软件复位	1发生软件复位
+		0:No software reset 
+		1:Software reset occurs [0没有软件复位	1发生软件复位]
 	*/
 	uint8_t Software_Reset:1;
 	

--- a/ADV2/BMS/Source/App/key_app.c
+++ b/ADV2/BMS/Source/App/key_app.c
@@ -2,20 +2,20 @@
 
 /**************************************************
  * @brie  :KEY_Init()
- * @note  :KEY初始化
- * @param :无
- * @retval:无
+ * @note  :KEY initialization [KEY初始化]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void KEY_Task(void)
 {
-	if(KEY1_State == 0)  //充电器供电按键不起作用
+	if(KEY1_State == 0)  //Charger power button does not work [充电器供电按键不起作用]
 	{
 		return;
 	}
 	
 	switch(KEY1_State)
 	{
-		case 1:  	//单击
+		case 1:  	//Click [单击]
 //			if(Flag.Power == 4)
 //			{
 //				NVIC_SystemReset();
@@ -28,23 +28,23 @@ void KEY_Task(void)
 			}
 		break;
 		
-		case 2:		//双击	
+		case 2:		//Double Click [双击]
 		
 		break;
 		
-		case 3:		//长按
+		case 3:		//Long Press [长按]
 			if(Flag.Power == 0)
 			{
 				Flag.Key_Boot = 1;
 				Flag.Power = 1;
 			}
-			else if(Flag.Charger_ON == 0) //开机充电器充电，按键不关机
+			else if(Flag.Charger_ON == 0) //Turn on the charger to charge, but press the button to not shut down [开机充电器充电，按键不关机]
 			{
 				Flag.Power = 3;
 			}
 		break;
 		
-		case 4:		//三按
+		case 4:		//Triple Press [三按]
 			
 		break;
 		

--- a/ADV2/BMS/Source/App/power_app.c
+++ b/ADV2/BMS/Source/App/power_app.c
@@ -5,33 +5,33 @@
 
 /**************************************************
  * @brie  :Power_On_Detection()
- * @note  :开机检测
- * @param :无
- * @retval:无
+ * @note  :Power on detection [开机检测]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void Power_On_Detection(void)
 {
-//	if((KEY1 == 0) && (CHARGER == 0))	//按键没按下，充电器没插入，关机
+//	if((KEY1 == 0) && (CHARGER == 0))	//The button is not pressed, the charger is not plugged in, and the power is turned off. [按键没按下，充电器没插入，关机]
 //	{
-//		//Flag.Power = 3;	//上电后按键没按下，关机
+//		//Flag.Power = 3;	//After powering on, the button is not pressed and the machine shuts down. [上电后按键没按下，关机]
 //		KEY1_State = 1;
 //	}
 //	else
 //	{
-//		if((KEY1 == 1) && (CHARGER == 0))	//按键开机
+//		if((KEY1 == 1) && (CHARGER == 0))	//Button to power on [按键开机]
 //		{
 //			KEY1_State = 1;
 //			Flag.Key_Boot = 1;
 //			Flag.Charger_Boot = 0;
 //			Flag.Power = 0;
 //		}
-//		else if((KEY1 == 0) && (CHARGER == 1))	//充电器开机
+//		else if((KEY1 == 0) && (CHARGER == 1))	//Charger turned on [充电器开机]
 //		{
 //			Flag.Key_Boot = 0;
 //			Flag.Charger_Boot = 1;
 //			Flag.Power = 1;
 //		}
-//		else if((KEY1 == 1) && (CHARGER == 1))	//按键和充电器同时开机
+//		else if((KEY1 == 1) && (CHARGER == 1))	//The button and charger are turned on at the same time [按键和充电器同时开机]
 //		{
 //			KEY1_State = 1;
 //			Flag.Key_Boot = 1;
@@ -40,16 +40,16 @@ void Power_On_Detection(void)
 //		}
 //	}
 	 
-	if(KEY1 == 1)	//按键开机
+	if(KEY1 == 1)	//Button to power on [按键开机]
 	{
 		KEY1_State = 1;
 		Flag.Key_Boot = 1;
 		Flag.Charger_Boot = 0;
 		Flag.Power = 0;	
 	}
-	else if(CHARGER == 1)	//充电器开机
+	else if(CHARGER == 1)	//Charger turned on [充电器开机]
 	{
-		User_Delay_xms(500);	//
+		User_Delay_xms(500);	
 		if((CHARGER == 1))	
 		{
 			Flag.Key_Boot = 0;
@@ -61,7 +61,7 @@ void Power_On_Detection(void)
 			Flag.Power = 3;	
 		}
 	}
-	else	//按键没按下，充电器没插入
+	else	//The button is not pressed and the charger is not plugged in. [按键没按下，充电器没插入]
 	{
 //		for(i=0; i<14; i++)
 //		{
@@ -96,15 +96,15 @@ void Power_On_Detection(void)
 	
 	if(Flag.Short_Circuit == 1)
 	{
-		Flag.Power = 3;	//短路直接关机
+		Flag.Power = 3;	//Direct shutdown due to short circuit [短路直接关机]
 	}
 }
 
 /**************************************************
  * @brie  :Power_Boot_Step()
- * @note  :电源开机
- * @param :无
- * @retval:无
+ * @note  :Power on [电源开机]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 static void Power_Boot_Step(void)
 {
@@ -144,7 +144,7 @@ static void Power_Boot_Step(void)
 				PDSG_OFF;
 				PCHG_OFF;
 				power_step = 0;
-				Flag.Power = 2;	//开机完成
+				Flag.Power = 2;	//Boot completed [开机完成]
 			}
 		break;
 		
@@ -156,28 +156,28 @@ static void Power_Boot_Step(void)
 
 /**************************************************
  * @brie  :Power_Task()
- * @note  :电源任务
- * @param :无
- * @retval:无
+ * @note  :Power tasks [电源任务]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void Power_Task(void)
 {
 		
 	switch(Flag.Power)
 	{
-		case 0:	//刚刚上电
+		case 0:	//Just powered on [刚刚上电]
 			
 		break;
 		
-		case 1://开机
+		case 1://Power on [开机]
 			Power_Boot_Step();
 		break;
 		
-		case 2://开机完成
+		case 2://Boot completed [开机完成]
 			
 		break;
 		
-		case 3://关机
+		case 3://Shut down [关机]
 			LED_OFF;
 			LDO_OFF;
 			DSG_OFF;
@@ -210,8 +210,8 @@ void Power_Task(void)
 			Enter_Low_Power();
 		break;
 		
-		case 4:	//关机后继续平衡充
-			if((newBals == 0) || (Flag.Short_Circuit == 1))		//平衡充结束
+		case 4:	//Continue balance charging after shutting down [关机后继续平衡充]
+			if((newBals == 0) || (Flag.Short_Circuit == 1))		//Balance charge ends [平衡充结束]
 			{
 				LED_OFF;
 				
@@ -238,9 +238,9 @@ void Power_Task(void)
 
 /**************************************************
  * @brie  :Charger_ON_Step()
- * @note  :充电器打开
- * @param :无
- * @retval:无
+ * @note  :Charger is on [充电器打开]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 static void Charger_ON_Step(void)
 {
@@ -257,7 +257,7 @@ static void Charger_ON_Step(void)
 			if(Software_Counter_1ms.CHARGER_ON >= 1000)
 			{
 				CHARG_ON;
-				Flag.Charger_ON = 1;	//充电器开打完成
+				Flag.Charger_ON = 1;	//The charger is turned on [充电器开打完成]
 
 				charger_step = 0;
 			}
@@ -271,13 +271,13 @@ static void Charger_ON_Step(void)
 
 /**************************************************
  * @brie  :Charger_Task()
- * @note  :充电器任务
- * @param :无
- * @retval:无
+ * @note  :Charger tasks [充电器任务]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void Charger_Task(void)
 {
-	if(CHARGER == 1)	//充电器插入
+	if(CHARGER == 1)	//Charger plugged in [充电器插入]
 	{
 		if(Flag.Power == 4)
 		{
@@ -297,19 +297,19 @@ void Charger_Task(void)
 	
 	if(Flag.Charger_Boot == 0)	
 	{
-//		if((Flag.Key_Boot == 0) && (Flag.Power != 4))	//充电器开机的	
+//		if((Flag.Key_Boot == 0) && (Flag.Power != 4))	//The charger is on [充电器开机的]
 //		{
-//			Flag.Power = 3;	//关机
+//			Flag.Power = 3;	//Shut down [关机]
 //		}
 //		else
 //		{
-//			CHARG_OFF;	//充电器拔出，不关机
+//			CHARG_OFF;	//The charger is pulled out and the phone does not shut down. [充电器拔出，不关机]
 //			Flag.Charger_ON = 0;
 //		}
-		CHARG_OFF;	//充电器拔出，不关机
+		CHARG_OFF;	//The charger is pulled out and the phone does not shut down. [充电器拔出，不关机]
 		Flag.Charger_ON = 0;
 	}
-	else if(Flag.Power == 2)	//开机完成
+	else if(Flag.Power == 2)	//Boot completed [开机完成]
 	{
 		if(Flag.Charger_ON == 0)
 		{
@@ -321,13 +321,13 @@ void Charger_Task(void)
 
 /**************************************************
  * @brie  :Automatic_Shutdown()
- * @note  :自动关机
- * @param :无
- * @retval:无
+ * @note  :Automatic shutdown [自动关机]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void Automatic_Shutdown(void)
 {
-	//转速在±100，并且充电器没有插入，并且平衡充结束，30分钟后关机
+	//The rotation speed is ±100, and the charger is not plugged in, and the balance charge is completed, and it will shut down after 30 minutes. [转速在±100，并且充电器没有插入，并且平衡充结束，30分钟后关机]
 	if(((VESC_CAN_RX_DATA.pSTATUS->Rpm < 100) && (VESC_CAN_RX_DATA.pSTATUS->Rpm > -100)) && (CHARGER == 0) && (newBals == 0))
 	{
 		if(Software_Counter_1ms.Power_Off >= 1800000)
@@ -340,7 +340,7 @@ void Automatic_Shutdown(void)
 		Software_Counter_1ms.Power_Off = 0;
 	}
 	
-	if(VESC_CAN_DATA.pBMS_I->Input_Current_BMS_IC.f > 0.3f)	//放电电流大于0.3A，计数器清零
+	if(VESC_CAN_DATA.pBMS_I->Input_Current_BMS_IC.f > 0.3f)	//The discharge current is greater than 0.3A and the counter is cleared. [放电电流大于0.3A，计数器清零]
 	{
 		Software_Counter_1ms.Power_Off = 0;
 	}	

--- a/ADV2/BMS/Source/App/vesc_can.c
+++ b/ADV2/BMS/Source/App/vesc_can.c
@@ -2,97 +2,97 @@
 	
 CAN_BMS_V_TOT 	BMS_V_TOT = 
 {
-	.Total_Voltage = 0,				//总电压
-	.Charge_Input_Voltage = 0,		//充电器电压
+	.Total_Voltage = 0,				//total voltage [总电压]
+	.Charge_Input_Voltage = 0,		//Charger voltage [充电器电压]
 };
 
 CAN_BMS_I		BMS_I = 
 {
-	.Input_Current = 0,				//输入电流
-	.Input_Current_BMS_IC = 0,		//BMS_IC电流
+	.Input_Current = 0,				//Input current [输入电流]
+	.Input_Current_BMS_IC = 0,		//BMS_IC current [BMS_IC电流]
 };
 
 
 CAN_BMS_AH_WH	BMS_AH_WH = 
 {
-	.Ah_Counter = 0,				//电池毫安时
-	.Wh_Counter = 0,				//电池W时 
+	.Ah_Counter = 0,				//Battery mAh [电池毫安时]
+	.Wh_Counter = 0,				//Battery Wh [电池W时]
 };
 
 CAN_BMS_V_CELL	BMS_V_CELL = 		
 {
-	.Group = 0,						//第几组
-	.BMS_String = 20,				//BMS串数
-	.BMS_Single_Voltage[0] = 0,		//单节电池电压
-	.BMS_Single_Voltage[1] = 0,		//单节电池电压
-	.BMS_Single_Voltage[2] = 0,		//单节电池电压
-	.BMS_Single_Voltage[3] = 0,		//单节电池电压	
-	.BMS_Single_Voltage[4] = 0,		//单节电池电压
-	.BMS_Single_Voltage[5] = 0,		//单节电池电压
-	.BMS_Single_Voltage[6] = 0,		//单节电池电压
-	.BMS_Single_Voltage[7] = 0,		//单节电池电压	
-	.BMS_Single_Voltage[8] = 0,		//单节电池电压
-	.BMS_Single_Voltage[9] = 0,		//单节电池电压
-	.BMS_Single_Voltage[10] = 0,	//单节电池电压
-	.BMS_Single_Voltage[11] = 0,	//单节电池电压	
-	.BMS_Single_Voltage[12] = 0,	//单节电池电压
-	.BMS_Single_Voltage[13] = 0,	//单节电池电压
-	.BMS_Single_Voltage[14] = 0,	//单节电池电压
-	.BMS_Single_Voltage[15] = 0,	//单节电池电压	
-	.BMS_Single_Voltage[16] = 0,	//单节电池电压
-	.BMS_Single_Voltage[17] = 0,	//单节电池电压	
-	.BMS_Single_Voltage[18] = 0,	//单节电池电压
-	.BMS_Single_Voltage[19] = 0,	//单节电池电压
+	.Group = 0,						//Which group [第几组]
+	.BMS_String = 20,				//BMS string number [BMS串数]
+	.BMS_Single_Voltage[0] = 0,		//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[1] = 0,		//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[2] = 0,		//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[3] = 0,		//Single battery voltage [单节电池电压]	
+	.BMS_Single_Voltage[4] = 0,		//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[5] = 0,		//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[6] = 0,		//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[7] = 0,		//Single battery voltage [单节电池电压]	
+	.BMS_Single_Voltage[8] = 0,		//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[9] = 0,		//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[10] = 0,	//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[11] = 0,	//Single battery voltage [单节电池电压]	
+	.BMS_Single_Voltage[12] = 0,	//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[13] = 0,	//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[14] = 0,	//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[15] = 0,	//Single battery voltage [单节电池电压]	
+	.BMS_Single_Voltage[16] = 0,	//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[17] = 0,	//Single battery voltage [单节电池电压]	
+	.BMS_Single_Voltage[18] = 0,	//Single battery voltage [单节电池电压]
+	.BMS_Single_Voltage[19] = 0,	//Single battery voltage [单节电池电压]
 };
 
 CAN_BMS_BAL		BMS_BAL = 
 {
-	.BMS_String = 20,				//BMS串数
-	.BMS_BAT.i = 0,					//单节电池状态
+	.BMS_String = 20,				//BMS string number [BMS串数]
+	.BMS_BAT.i = 0,					//Single battery status [单节电池状态]
 };
 
 CAN_BMS_TEMPS	BMS_TEMPS =
 {
-	.Group = 0,						//第几组
-	.BMS_Single_Temp[0] = 0,		//单节电池温度
-	.BMS_Single_Temp[1] = 0,		//单节电池温度
-	.BMS_Single_Temp[2] = 0,		//单节电池温度
-	.BMS_Single_Temp[3] = 0,		//单节电池温度
-	.BMS_Single_Temp[4] = 0,		//单节电池温度
-	.BMS_Single_Temp[5] = 0,		//单节电池温度
-	.BMS_Single_Temp[6] = 0,		//单节电池温度
-	.BMS_Single_Temp[7] = 0,		//单节电池温度
-	.BMS_Single_Temp[8] = 0,		//单节电池温度
-	.BMS_Single_Temp[9] = 0,		//单节电池温度
+	.Group = 0,						//Which group [第几组]
+	.BMS_Single_Temp[0] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[1] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[2] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[3] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[4] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[5] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[6] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[7] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[8] = 0,		//Single battery temperature [单节电池温度]
+	.BMS_Single_Temp[9] = 0,		//Single battery temperature [单节电池温度]
 };
 
 CAN_BMS_HUM		BMS_HUM = 
 {
-	.Humidity = 0,					//湿度	0-10000(0%-100%);
-	.Temp_Hum_Sensor = 0,			//温度	-10000-10000(-100°-100°)
-	.Temp_IC = 0,					//IC温度
+	.Humidity = 0,					//Humidity 0-10000(0%-100%); [湿度	0-10000(0%-100%);]
+	.Temp_Hum_Sensor = 0,			//Temperature -10000-10000(-100°-100°) [温度	-10000-10000(-100°-100°)]
+	.Temp_IC = 0,					//IC Temperature [IC温度]
 };
 
 CAN_BMS_SOC_SOH_TEMP_STAT	BMS_SOC_SOH_TEMP_STAT = 
 {
-	.V_Cell_Min = 0,				//单节电池最低电压 扩大1000倍发送
-	.V_Cell_Max = 0,				//单节电池最高电压 扩大1000倍发送
+	.V_Cell_Min = 0,				//The lowest voltage of a single battery is enlarged 1000 times and sent [单节电池最低电压 扩大1000倍发送]
+	.V_Cell_Max = 0,				//The maximum voltage of a single battery is expanded 1000 times and sent [单节电池最高电压 扩大1000倍发送]
 	.Soc = 0,						//0-255(0%-100%)
 	.Soh = 0,						//0-255(0%-100%)
-	.T_Cell_Max = 0,				//单节电池最大温度
+	.T_Cell_Max = 0,				//Maximum temperature of single battery [单节电池最大温度]
 	.Stat = 0,						//
 };
 
 CAN_BMS_AH_WH_CHG_TOTAL		BMS_AH_WH_CHG_TOTAL =
 {
-	.Ah_Charge_Total = 0,			//安时
-	.Wh_Charge_Total = 0,			//瓦时
+	.Ah_Charge_Total = 0,			//An hour [安时]
+	.Wh_Charge_Total = 0,			//Watt hour [瓦时]
 };
 
 CAN_BMS_AH_WH_DIS_TOTAL		BMS_AH_WH_DIS_TOTAL =
 {
-	.Ah_Discharge_Total = 0,		//安时
-	.Wh_Discharge_Total = 0,		//瓦时
+	.Ah_Discharge_Total = 0,		//An hour [安时]
+	.Wh_Discharge_Total = 0,		//Watt hour [瓦时]
 };	
 
 VESC_CAN_TYPE VESC_CAN_DATA = 
@@ -111,10 +111,10 @@ VESC_CAN_TYPE VESC_CAN_DATA =
 
 /**************************************************
  * @brie  :VESC_Set_BMS_V_TOT()
- * @note  :设置总电压 	充电器电压
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set the total voltage charger voltage [设置总电压 	充电器电压]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_V_TOT(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -143,10 +143,10 @@ void VESC_Set_BMS_V_TOT(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data
 	
 /**************************************************
  * @brie  :VESC_Set_BMS_I()
- * @note  :设置输入电流 	BMS_IC电流
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set input current BMS_IC current [设置输入电流 	BMS_IC电流]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_I(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -175,10 +175,10 @@ void VESC_Set_BMS_I(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 
 /**************************************************
  * @brie  :VESC_Set_BMS_AH_WH()
- * @note  :设置电池毫安时 	电池W时 
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set battery mAh Battery W hours [设置电池毫安时 	电池W时 ]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_AH_WH(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -207,10 +207,10 @@ void VESC_Set_BMS_AH_WH(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data
 
 /**************************************************
  * @brie  :VESC_Set_BMS_V_CELL()
- * @note  :设置单节电池电压 
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set single battery voltage [设置单节电池电压]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_V_CELL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -247,10 +247,10 @@ void VESC_Set_BMS_V_CELL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_dat
 
 /**************************************************
  * @brie  :VESC_Set_BMS_BAL()
- * @note  :设置单节电池状态 
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set single battery status [设置单节电池状态]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_BAL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -279,10 +279,10 @@ void VESC_Set_BMS_BAL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 
 /**************************************************
  * @brie  :VESC_Set_BMS_TEMPS()
- * @note  :设置温度 
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set temperature [设置温度 ]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_TEMPS(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -321,10 +321,10 @@ void VESC_Set_BMS_TEMPS(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data
 
 /**************************************************
  * @brie  :VESC_Set_BMS_HUM()
- * @note  :设置湿度 温度 IC温度  
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set humidity temperature IC temperature [设置湿度 温度 IC温度 ]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_HUM(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -353,15 +353,15 @@ void VESC_Set_BMS_HUM(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 
 /**************************************************
  * @brie  :VESC_Set_BMS_SOC_SOH_TEMP_STAT()
- * @note  :设置单节电池最低电压
- *			   单节电池最高电压
- *			    Soc
- *				Soh
- *			   单节电池最大温度
- *			   状态
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set the minimum voltage of a single battery [设置单节电池最低电压]
+ *		   Maximum voltage of a single battery [单节电池最高电压]
+ *	       Soc
+ *		   Soh
+ *		   Maximum temperature of single battery [单节电池最大温度]
+ *		   State [状态]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_SOC_SOH_TEMP_STAT(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -390,10 +390,10 @@ void VESC_Set_BMS_SOC_SOH_TEMP_STAT(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *v
 
 /**************************************************
  * @brie  :VESC_Set_BMS_AH_WH_CHG_TOTAL()
- * @note  :设置充电安时 	充电瓦时
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set charging ampere-hour charging watt-hour [设置充电安时 充电瓦时]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_AH_WH_CHG_TOTAL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -422,10 +422,10 @@ void VESC_Set_BMS_AH_WH_CHG_TOTAL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *ves
 
 /**************************************************
  * @brie  :VESC_Set_BMS_AH_WH_DIS_TOTAL()
- * @note  :设置安时 瓦时
- * @param :can_tx_struct	CAN发送结构体
+ * @note  :Set ampere-hours watt-hours [设置安时 瓦时]
+ * @param :can_tx_struct	CAN sending structure [CAN发送结构体]
  *		   vesc_can_data	VESC_CAN_TYPE
- * @retval:无
+ * @retval:none [无]
  **************************************************/
 void VESC_Set_BMS_AH_WH_DIS_TOTAL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *vesc_can_data)
 {
@@ -454,35 +454,35 @@ void VESC_Set_BMS_AH_WH_DIS_TOTAL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *ves
 
 CAN_STATUS STATUS = 
 {
-	.Rpm = 0,			//转速
-	.Duty_Cycle = 0,	//占空比
-	.Total_Current = 0,	//总电流
+	.Rpm = 0,			//Speed [转速]
+	.Duty_Cycle = 0,	//Duty cycle [占空比]
+	.Total_Current = 0,	//Total current [总电流]
 };
 
 CAN_STATUS_2 STATUS_2 = 
 {
-	.Amp_Hours_Charged = 0,	//充电的安时
-	.Amp_Hours = 0,			//消耗的安时
+	.Amp_Hours_Charged = 0,	//Charging ampere hours [充电的安时]
+	.Amp_Hours = 0,			//Hours consumed [消耗的安时]
 };
 
 CAN_STATUS_3 STATUS_3 = 
 {
-	.Watt_Hours_Charged = 0,	//充电的瓦时
-	.Watt_Hours = 0,			//消耗的瓦时
+	.Watt_Hours_Charged = 0,	//Charging watt hours [充电的瓦时]
+	.Watt_Hours = 0,			//Watt hours consumed [消耗的瓦时]
 };
 
 CAN_STATUS_4 STATUS_4 = 
 {
-	.PID_Pos = 0,				//不清楚数据类型
-	.Total_Input_Current = 0,	//输入总电流
-	.Motor_Temp = 0,			//电机温度
-	.MOSFET_Temp = 0,			//MOS管温度
+	.PID_Pos = 0,				//Not sure about data type [不清楚数据类型]
+	.Total_Input_Current = 0,	//Input total current [输入总电流]
+	.Motor_Temp = 0,			//Motor temperature [电机温度]
+	.MOSFET_Temp = 0,			//Mosfet temperature [MOS管温度]
 };
 
 CAN_STATUS_5 STATUS_5 = 
 {
-	.Input_Voltage = 0,		//输入电压
-	.Tachometer_Value = 0,	//转速表?不确定
+	.Input_Voltage = 0,		//input voltage [输入电压]
+	.Tachometer_Value = 0,	//Tachometer? Not sure [转速表?不确定]
 };
 
 VESC_CAN_RX_TYPE VESC_CAN_RX_DATA = 

--- a/ADV2/BMS/Source/App/vesc_can.h
+++ b/ADV2/BMS/Source/App/vesc_can.h
@@ -38,68 +38,68 @@ typedef union
 
 typedef struct
 {
-	FLOAT_INT_TYP 	Total_Voltage;			//总电压
-	FLOAT_INT_TYP 	Charge_Input_Voltage;	//充电器电压
+	FLOAT_INT_TYP 	Total_Voltage;			//total voltage [总电压]
+	FLOAT_INT_TYP 	Charge_Input_Voltage;	//Charger voltage [充电器电压]
 }CAN_BMS_V_TOT;
 
 typedef struct
 {
-	FLOAT_INT_TYP 	Input_Current;			//输入电流
-	FLOAT_INT_TYP 	Input_Current_BMS_IC;	//BMS_IC电流
+	FLOAT_INT_TYP 	Input_Current;			//Input current [输入电流]
+	FLOAT_INT_TYP 	Input_Current_BMS_IC;	//BMS_IC current [BMS_IC电流]
 }CAN_BMS_I;
 
 typedef struct
 {
-	FLOAT_INT_TYP 	Ah_Counter;				//电池毫安时
-	FLOAT_INT_TYP 	Wh_Counter;				//电池W时 
+	FLOAT_INT_TYP 	Ah_Counter;				//Battery mAh [电池毫安时]
+	FLOAT_INT_TYP 	Wh_Counter;				//Battery Wh [电池W时]
 }CAN_BMS_AH_WH;
 
 typedef struct
 {
-	uint8_t         Group;					//第几组	一帧报文最多设置3组电池电压
-	uint8_t			BMS_String;				//BMS串数
-	uint16_t		BMS_Single_Voltage[20];	//单节电池电压	扩大1000倍发送
+	uint8_t         Group;					//In which group, one frame of message can set up to 3 groups of battery voltages. [第几组	一帧报文最多设置3组电池电压]
+	uint8_t			BMS_String;				//BMS string number [BMS串数]
+	uint16_t		BMS_Single_Voltage[20];	//Single cell battery voltage expanded 1000 times to send [单节电池电压	扩大1000倍发送]
 }CAN_BMS_V_CELL;
 
 typedef struct
 {
-	uint8_t			BMS_String;				//BMS串数
-	INT32_BIT_TYP	BMS_BAT;				//单节电池状态
+	uint8_t			BMS_String;				//BMS string number [BMS串数]
+	INT32_BIT_TYP	BMS_BAT;				//Single battery status [单节电池状态]
 }CAN_BMS_BAL;
 
 typedef struct
 {
-	uint8_t         Group;					//第几组	一帧报文最多设置3组电池电压
-	uint16_t		BMS_Single_Temp[10];	//电池温度	扩大100倍发送
+	uint8_t         Group;					//In which group, one frame of message can set up to 3 groups of battery voltages. [第几组	一帧报文最多设置3组电池电压]
+	uint16_t		BMS_Single_Temp[10];	//Battery temperature enlarged 100 times to send [电池温度	扩大100倍发送]
 }CAN_BMS_TEMPS;
 
 typedef struct
 {
-	uint16_t 		Humidity;				//湿度	0-10000(0%-100%);
-	int16_t			Temp_Hum_Sensor;		//温度	-10000-10000(-100°-100°)
-	int16_t			Temp_IC;				//IC温度
+	uint16_t 		Humidity;				//Humidity 0-10000(0%-100%) [湿度	0-10000(0%-100%);]
+	int16_t			Temp_Hum_Sensor;		//Temperature -10000-10000(-100°-100°) [温度	-10000-10000(-100°-100°)]
+	int16_t			Temp_IC;				//IC temperature [IC温度]
 }CAN_BMS_HUM;
 
 typedef struct
 {
-	uint16_t		V_Cell_Min;				//单节电池最低电压 扩大1000倍发送
-	uint16_t		V_Cell_Max;				//单节电池最高电压 扩大1000倍发送
-	uint8_t 		Soc;					//0-255(0%-100%) 充电状态
-	uint8_t			Soh;					//0-255(0%-100%) 健康状态
-	uint8_t			T_Cell_Max;				//单节电池最大温度
-	uint8_t			Stat;					//
+	uint16_t		V_Cell_Min;				//The lowest voltage of a single battery is enlarged 1000 times and sent [单节电池最低电压 扩大1000倍发送]
+	uint16_t		V_Cell_Max;				//The maximum voltage of a single battery is expanded 1000 times and sent [单节电池最高电压 扩大1000倍发送]
+	uint8_t 		Soc;					//Charging status 0-255(0%-100%) [0-255(0%-100%) 充电状态]
+	uint8_t			Soh;					//Health status 0-255(0%-100%) [0-255(0%-100%) 健康状态]
+	uint8_t			T_Cell_Max;				//Maximum temperature of single battery [单节电池最大温度]
+	uint8_t			Stat;					
 }CAN_BMS_SOC_SOH_TEMP_STAT;
 
 typedef struct
 {
-	FLOAT_INT_TYP	Ah_Charge_Total;		//充电安时
-	FLOAT_INT_TYP   Wh_Charge_Total;		//充电瓦时
+	FLOAT_INT_TYP	Ah_Charge_Total;		//Charging ampere hours [充电安时]
+	FLOAT_INT_TYP   Wh_Charge_Total;		//Charging watt hours [充电瓦时]
 }CAN_BMS_AH_WH_CHG_TOTAL;
 
 typedef struct
 {
-	FLOAT_INT_TYP	Ah_Discharge_Total;		//安时
-	FLOAT_INT_TYP   Wh_Discharge_Total;		//瓦时
+	FLOAT_INT_TYP	Ah_Discharge_Total;		//An hour [安时]
+	FLOAT_INT_TYP   Wh_Discharge_Total;		//Watt hour [瓦时]
 }CAN_BMS_AH_WH_DIS_TOTAL;
 
 typedef struct
@@ -119,30 +119,30 @@ typedef struct
 
 typedef struct
 {
-	FLOAT_INT_TYP 	Total_Voltage;			//总电压
-	FLOAT_INT_TYP 	Charge_Input_Voltage;	//充电器电压	
-	FLOAT_INT_TYP 	Input_Current;			//输入电流
-	FLOAT_INT_TYP 	Input_Current_BMS_IC;	//BMS_IC电流
-	FLOAT_INT_TYP 	Ah_Counter;				//电池毫安时
-	FLOAT_INT_TYP 	Wh_Counter;				//电池W时 
-	uint16_t 		Humidity;				//湿度	0-10000(0%-100%);
-	int16_t			Temp_Hum_Sensor;		//温度	-10000-10000(-100°-100°)
-	int16_t			Temp_IC;				//IC温度
-	uint16_t		V_Cell_Min;				//单节电池最低电压 扩大1000倍发送
-	uint16_t		V_Cell_Max;				//单节电池最高电压 扩大1000倍发送
+	FLOAT_INT_TYP 	Total_Voltage;			//Total voltage [总电压]
+	FLOAT_INT_TYP 	Charge_Input_Voltage;	//Charger voltage [充电器电压]
+	FLOAT_INT_TYP 	Input_Current;			//Input current [输入电流]
+	FLOAT_INT_TYP 	Input_Current_BMS_IC;	//BMS_IC current [BMS_IC电流]
+	FLOAT_INT_TYP 	Ah_Counter;				//Battery mAh [电池毫安时]
+	FLOAT_INT_TYP 	Wh_Counter;				//Battery Wh [电池W时]
+	uint16_t 		Humidity;				//Humidity 0-10000(0%-100%) [湿度	0-10000(0%-100%);]
+	int16_t			Temp_Hum_Sensor;		//Temperature -10000-10000(-100°-100°) [温度	-10000-10000(-100°-100°)]
+	int16_t			Temp_IC;				//IC temperature [IC温度]
+	uint16_t		V_Cell_Min;				//The lowest voltage of a single battery is enlarged 1000 times and sent [单节电池最低电压 扩大1000倍发送]
+	uint16_t		V_Cell_Max;				//The maximum voltage of a single battery is expanded 1000 times and sent [单节电池最高电压 扩大1000倍发送]
 	uint8_t 		Soc;					//0-255(0%-100%)
 	uint8_t			Soh;					//0-255(0%-100%)
-	uint8_t			T_Cell_Max;				//单节电池最大温度
+	uint8_t			T_Cell_Max;				//Maximum temperature of single battery [单节电池最大温度]
 	uint8_t			Stat;					//
-	FLOAT_INT_TYP	Ah_Charge_Total;		//安时
-	FLOAT_INT_TYP   Wh_Charge_Total;		//瓦时
-	FLOAT_INT_TYP	Ah_Discharge_Total;		//安时
-	FLOAT_INT_TYP   Wh_Discharge_Total;		//瓦时
-	uint8_t         Group;					//第几组	一帧报文最多设置3组电池电压
-	uint8_t			BMS_String;				//BMS串数
-	uint16_t		BMS_Single_Voltage[20];	//单节电池电压	扩大1000倍发送
-	uint16_t		BMS_Single_Temp[10];	//电池温度	扩大100倍发送
-	uint32_t		BMS_Single_Stat;		//单节电池状态	
+	FLOAT_INT_TYP	Ah_Charge_Total;		//An hour [安时]
+	FLOAT_INT_TYP   Wh_Charge_Total;		//Watt hour [瓦时]
+	FLOAT_INT_TYP	Ah_Discharge_Total;		//An hour [安时]
+	FLOAT_INT_TYP   Wh_Discharge_Total;		//Watt hour [瓦时]
+	uint8_t         Group;					//In which group, one frame of message can set up to 3 groups of battery voltages. [第几组	一帧报文最多设置3组电池电压]
+	uint8_t			BMS_String;				//BMS string number [BMS串数]
+	uint16_t		BMS_Single_Voltage[20];	//Single cell battery voltage expanded 1000 times to send [单节电池电压	扩大1000倍发送]
+	uint16_t		BMS_Single_Temp[10];	//Battery temperature enlarged 100 times to send [电池温度	扩大100倍发送]
+	uint32_t		BMS_Single_Stat;		//Single battery status [单节电池状态]
 	
 	CAN_PACKET_ID 	VESC_CAN_CMD;
 	
@@ -163,35 +163,35 @@ void VESC_Set_BMS_AH_WH_DIS_TOTAL(CanTxMessage *can_tx_struct,VESC_CAN_TYPE *ves
 
 typedef struct
 {
-	int32_t Rpm;			//转速
-	float	Duty_Cycle;		//占空比
-	float	Total_Current;	//总电流
+	int32_t Rpm;			//Speed [转速]
+	float	Duty_Cycle;		//Duty Cycle [占空比]
+	float	Total_Current;	//Total Current [总电流]
 }CAN_STATUS;
 
 typedef struct
 {
-	float	Amp_Hours_Charged;	//充电的安时
-	float	Amp_Hours;			//消耗的安时
+	float	Amp_Hours_Charged;	//Charging ampere hours [充电的安时]
+	float	Amp_Hours;			//Hours consumed [消耗的安时]
 }CAN_STATUS_2;
 
 typedef struct
 {
-	float	Watt_Hours_Charged;	//充电的瓦时
-	float	Watt_Hours;			//消耗的瓦时
+	float	Watt_Hours_Charged;	//Charging watt hours [充电的瓦时]
+	float	Watt_Hours;			//Watt hours consumed [消耗的瓦时]
 }CAN_STATUS_3;
 
 typedef struct
 {
-	float 	PID_Pos;				//不清楚数据类型
-	float 	Total_Input_Current;	//输入总电流
-	float 	Motor_Temp;				//电机温度
-	float 	MOSFET_Temp;			//MOS管温度
+	float 	PID_Pos;				//Not sure about data type [不清楚数据类型]
+	float 	Total_Input_Current;	//Input total current [输入总电流]
+	float 	Motor_Temp;				//Motor temperature [电机温度]
+	float 	MOSFET_Temp;			//Mosfet temperature [MOS管温度]
 }CAN_STATUS_4;
 
 typedef struct
 {
-	float 	Input_Voltage;		//输入电压
-	int32_t Tachometer_Value;	//转速表?不确定
+	float 	Input_Voltage;		//input voltage [输入电压]
+	int32_t Tachometer_Value;	//Tachometer? Not sure [转速表?不确定]
 }CAN_STATUS_5;
 
 typedef struct

--- a/ADV2/BMS/Source/App/vesc_can_app.c
+++ b/ADV2/BMS/Source/App/vesc_can_app.c
@@ -1,20 +1,20 @@
 #include "vesc_can_app.h"
 
 /*
-	CAN_TX_Config.StdId 	//标准帧ID
-	CAN_TX_Config.ExtId		//扩展帧ID
-	CAN_TX_Config.IDE		//扩展帧还是标准帧
-	CAN_TX_Config.RTR		//远程帧还是数据帧
-	CAN_TX_Config.DLC		//数据长度0-8
-	CAN_TX_Config.Data[8]	//发送的数据 CAN总线一帧报文最多发8个字节
+	CAN_TX_Config.StdId 	//Standard frame ID [标准帧ID]
+	CAN_TX_Config.ExtId		//Extended frame ID [扩展帧ID]
+	CAN_TX_Config.IDE		//Extended frame or standard frame [扩展帧还是标准帧]
+	CAN_TX_Config.RTR		//Remote frame or data frame [远程帧还是数据帧]
+	CAN_TX_Config.DLC		//Data length 0-8 [数据长度0-8]
+	CAN_TX_Config.Data[8]	//Data sent: A maximum of 8 bytes can be sent in one frame of the CAN bus. [发送的数据 CAN总线一帧报文最多发8个字节]
 */
 CanTxMessage CAN_TX_Config;
 
 /**************************************************
  * @brie  :VESC_CAN_Task()
- * @note  :VESC_CAN任务
- * @param :无
- * @retval:无
+ * @note  :VESC_CAN Task [VESC_CAN任务]
+ * @param :none [无]
+ * @retval:none [无]
  **************************************************/
 void VESC_CAN_Task(void)
 {
@@ -28,86 +28,86 @@ void VESC_CAN_Task(void)
 	//VESC_CAN_DATA.pBMS_I->Input_Current.f += 0.001f;
 	switch(vesc_can_send_step)
 	{
-		case 0:	//发送总电压
+		case 0:	//Send total voltage [发送总电压]
 			VESC_Set_BMS_V_TOT(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 			
-		case 1:	//发送电池电压 1-2-3
+		case 1:	//Send battery voltage 1-2-3 [发送电池电压 1-2-3]
 			VESC_CAN_DATA.pBMS_V_CELL->Group = 0;
 			VESC_Set_BMS_V_CELL(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 2:	//发送电池电压 4-5-6
+		case 2:	//Send battery voltage 4-5-6 [发送电池电压 4-5-6]
 			VESC_CAN_DATA.pBMS_V_CELL->Group = 3;
 			VESC_Set_BMS_V_CELL(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 3: //发送电池电压 7-8-9
+		case 3: //Send battery voltage 7-8-9 [发送电池电压 7-8-9]
 			VESC_CAN_DATA.pBMS_V_CELL->Group = 6;
 			VESC_Set_BMS_V_CELL(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 4://发送电池电压 10-11-12
+		case 4: //Send battery voltage 10-11-12 [发送电池电压 10-11-12]
 			VESC_CAN_DATA.pBMS_V_CELL->Group = 9;
 			VESC_Set_BMS_V_CELL(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 5://发送电池电压 13-14-15
+		case 5: //Send battery voltage 13-14-15 [发送电池电压 13-14-15]
 			VESC_CAN_DATA.pBMS_V_CELL->Group = 12;
 			VESC_Set_BMS_V_CELL(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 6://发送电池电压 16-17-18
+		case 6: //Send battery voltage 16-17-18 [发送电池电压 16-17-18]
 			VESC_CAN_DATA.pBMS_V_CELL->Group = 15;
 			VESC_Set_BMS_V_CELL(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 7://发送电池电压 19-20
+		case 7: //Send battery voltage 19-20 [发送电池电压 19-20]
 			VESC_CAN_DATA.pBMS_V_CELL->Group = 18;
 			VESC_Set_BMS_V_CELL(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 8://发送电池电压状态
+		case 8: //Send battery voltage status [发送电池电压状态]
 			VESC_Set_BMS_BAL(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 9://发送电池电流
+		case 9: //Send battery current [发送电池电流]
 			VESC_Set_BMS_I(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 10://发送IC温度
+		case 10: //Send IC temperature [发送IC温度]
 			VESC_Set_BMS_HUM(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 11://发送NTC温度
+		case 11: //Send NTC temperature [发送NTC温度]
 			VESC_CAN_DATA.pBMS_TEMPS->Group = 0;
 			VESC_Set_BMS_TEMPS(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 12://发送电流
+		case 12: //Send current [发送电流]
 			VESC_Set_BMS_I(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 13://发送错误代码
+		case 13: //Send error code [发送错误代码]
 			VESC_CAN_DATA.pBMS_TEMPS->Group = 3;
 			VESC_Set_BMS_TEMPS(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step++;
 		break;
 		
-		case 14://发送错误代码
+		case 14: //Send error code [发送错误代码]
 			VESC_CAN_DATA.pBMS_TEMPS->Group = 6;
 			VESC_Set_BMS_TEMPS(&CAN_TX_Config,&VESC_CAN_DATA);
 			vesc_can_send_step = 0;


### PR DESCRIPTION
I've modified the code comments to include an english translation (via google translate). 
The original chinese comment is left in place trailing the translation.

`english translation [original chinese comment]`

I can see some items that need addressing and/or correcting, but I've committed to a direct translation in the first instance. 